### PR TITLE
fix(lint): use native eslint-config-next flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     ignores: [
       "node_modules/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,14 +33,13 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3",
         "@playwright/test": "1.60.0",
         "@types/dotenv": "^6.1.1",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "dotenv": "^17.2.3",
-        "eslint": "^9.39.4",
+        "eslint": "^9",
         "eslint-config-next": "^16.1",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3",
     "@playwright/test": "1.60.0",
     "@types/dotenv": "^6.1.1",
     "@types/node": "^25",

--- a/scripts/validate-config.ts
+++ b/scripts/validate-config.ts
@@ -25,8 +25,8 @@ const result = configSchema.safeParse(configData);
 
 if (result.success) {
   console.log('✅ The config.json file is valid!');
-  console.log(`   - ${configData.hunts.length} hunt(s)`);
-  configData.hunts.forEach((hunt: any) => {
+  console.log(`   - ${result.data.hunts.length} hunt(s)`);
+  result.data.hunts.forEach((hunt) => {
     console.log(`   - "${hunt.name}" with ${hunt.places.length} place(s)`);
   });
   process.exit(0);

--- a/tests/pages/BasePage.ts
+++ b/tests/pages/BasePage.ts
@@ -33,7 +33,7 @@ export class BasePage {
             await modal.waitFor({ state: 'hidden', timeout: 3000 });
           }
         }
-      } catch (e) {
+      } catch {
         // Ignore if modal is already closed
       }
     }
@@ -61,7 +61,7 @@ export class BasePage {
         await toastClose.click();
         await expect(toast).not.toBeVisible({ timeout: 3000 });
       }
-    } catch (e) {
+    } catch {
       // Toast may have already disappeared
     }
   }

--- a/tests/pages/CluePage.ts
+++ b/tests/pages/CluePage.ts
@@ -27,7 +27,7 @@ export abstract class ClueBasePage extends BasePage {
     try {
       await this.verifySuccessToast(expectedMessage);
       await this.closeToast();
-    } catch (e) {
+    } catch {
       // Toast handling skipped
     }
 
@@ -255,7 +255,7 @@ export class PageFlipClue extends ClueBasePage {
           await this.page.mouse.up();
           await this.wait(3500); // Extended wait for animation
           return;
-        } catch (e) {
+        } catch {
           // Swipe failed, try other strategies
         }
 
@@ -266,7 +266,7 @@ export class PageFlipClue extends ClueBasePage {
           await this.page.touchscreen.tap(pageBox.x + pageBox.width * 0.5, centerY);
           await this.wait(3500);
           return;
-        } catch (e) {
+        } catch {
           // Touch tap failed
         }
 
@@ -278,7 +278,7 @@ export class PageFlipClue extends ClueBasePage {
           await this.page.mouse.click(clickX, centerY);
           await this.wait(3500);
           return;
-        } catch (e) {
+        } catch {
           // All strategies failed
         }
       }
@@ -365,7 +365,7 @@ export class PageFlipClue extends ClueBasePage {
     try {
       await this.verifySuccessToast();
       await this.closeToast();
-    } catch (e) {
+    } catch {
       // Toast handling skipped
     }
 

--- a/tests/pages/HuntApp.ts
+++ b/tests/pages/HuntApp.ts
@@ -159,7 +159,7 @@ export class HuntApp {
 
     try {
       await this.map.closeToast();
-    } catch (e) {
+    } catch {
       // Toast handling skipped
     }
 

--- a/tests/pages/MapPage.ts
+++ b/tests/pages/MapPage.ts
@@ -1,4 +1,4 @@
-import {expect, Page} from '@playwright/test';
+import {expect, Page, Request, Response} from '@playwright/test';
 import {BasePage} from './BasePage';
 
 /**
@@ -88,14 +88,14 @@ export class MapPage extends BasePage {
         let requestFailed = false;
         let requestSucceeded = false;
 
-        const requestFailedHandler = (request: any) => {
+        const requestFailedHandler = (request: Request) => {
           if (request.url().includes('nominatim.openstreetmap.org')) {
             console.log(`Nominatim request failed on attempt ${attempt} for "${query}"`);
             requestFailed = true;
           }
         };
 
-        const responseHandler = (response: any) => {
+        const responseHandler = (response: Response) => {
           if (response.url().includes('nominatim.openstreetmap.org') && response.ok()) {
             requestSucceeded = true;
           }


### PR DESCRIPTION
## Summary
- `npm run lint` was crashing on `main` with `TypeError: Converting circular structure to JSON`. Cause: `eslint-config-next` 16 ships **flat config arrays**, but `eslint.config.mjs` wrapped them in `FlatCompat.extends()`, which is only meant for legacy `.eslintrc`-style configs.
- Import the flat configs directly (`eslint-config-next/core-web-vitals` + `eslint-config-next/typescript`) and remove the now-unused `@eslint/eslintrc` dependency.
- Fix the lint issues this surfaced (previously masked by the crash):
  - `no-explicit-any` in `scripts/validate-config.ts` (use the typed Zod `result.data`) and `tests/pages/MapPage.ts` (use Playwright `Request`/`Response` types).
  - `no-unused-vars` unused `catch (e)` bindings → optional catch binding.

## Test plan
- [x] `npm run lint` passes with 0 errors / 0 warnings
- [x] `npm run validate:config` passes
- [x] `npm run build` passes
- [x] Playwright `map.spec.ts` passes on Chromium (exercises the edited `MapPage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)